### PR TITLE
Feat: 온보딩 내 세그먼트 뷰의 커스텀 디바이더 완성

### DIFF
--- a/kko_okk/Views/OnBordingViews/OnBoardingMainView.swift
+++ b/kko_okk/Views/OnBordingViews/OnBoardingMainView.swift
@@ -25,9 +25,9 @@ struct OnBoardingMainView: View {
 }
 
 
-struct OnBoardingMainView_Previews: PreviewProvider {
-    static var previews: some View {
-        OnBoardingMainView()
-            .previewInterfaceOrientation(.landscapeLeft)
-    }
-}
+//struct OnBoardingMainView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        OnBoardingMainView()
+//            .previewInterfaceOrientation(.landscapeLeft)
+//    }
+//}

--- a/kko_okk/Views/OnBordingViews/OnBoardingSegmentView.swift
+++ b/kko_okk/Views/OnBordingViews/OnBoardingSegmentView.swift
@@ -44,6 +44,7 @@ struct OnBoardingSegmentView: View {
                         .foregroundColor(Color(hex: "DDDDDD"))
                         .frame(height: 2)
                         .padding(.top, -15)
+                        .frame(width: widthValue)  // Text의 물리적 길이가 저장된 widthValue를 받아서 프레임 사이즈 결정
                 }
 
                 VStack {
@@ -55,7 +56,10 @@ struct OnBoardingSegmentView: View {
                         .foregroundColor(Color(hex: "FFFFFF"))
                         .frame(height: 2)
                         .padding(.top, -15)
+                        .frame(width: widthValue)
                 }
+
+                Spacer()  // leading 포지션으로 정렬하기 위한 스페이서
             }
         }
     }


### PR DESCRIPTION
### Motivation
- 온보딩 내 세그먼트 뷰의 커스텀 디바이더 사이즈 자동 조절 코드 작성

### Key Changes
- GeometryReader와 PreferenceKey를 활용하여 Text의 화면 내 길이만큼 커스텀 디바이더의 길이를 자동으로 조절

### To Reviewers
- 오.. 이거 하는 데 꽤 오래 걸렸음ㄷㄷ