### PR TITLE
[Fix] Gesture 중첩 문제 해결

### DIFF
--- a/kko_okk.xcodeproj/project.pbxproj
+++ b/kko_okk.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		A816CAAC285C0D900026C06A /* PromisePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = A816CAAB285C0D900026C06A /* PromisePair.swift */; };
 		A81DE5FB285326B4009E9938 /* LicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DE5FA285326B4009E9938 /* LicenseView.swift */; };
 		A81DE5FD285326C7009E9938 /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DE5FC285326C7009E9938 /* EditView.swift */; };
+		A87AC2AF29E35689003B0D39 /* SwiftUIDelayedGesture in Frameworks */ = {isa = PBXBuildFile; productRef = A87AC2AE29E35689003B0D39 /* SwiftUIDelayedGesture */; };
 		A8A477212849FB430005B4E2 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A477202849FB430005B4E2 /* Font.swift */; };
 		A8A477222849FB430005B4E2 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A477202849FB430005B4E2 /* Font.swift */; };
 		A8A477232849FB430005B4E2 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A477202849FB430005B4E2 /* Font.swift */; };
@@ -226,6 +227,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A87AC2AF29E35689003B0D39 /* SwiftUIDelayedGesture in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -554,6 +556,9 @@
 			dependencies = (
 			);
 			name = kko_okk;
+			packageProductDependencies = (
+				A87AC2AE29E35689003B0D39 /* SwiftUIDelayedGesture */,
+			);
 			productName = kko_okk;
 			productReference = 9D55B4012846289000AFD9C5 /* kko_okk.app */;
 			productType = "com.apple.product-type.application";
@@ -627,6 +632,9 @@
 				ko,
 			);
 			mainGroup = 9D55B3F82846289000AFD9C5;
+			packageReferences = (
+				A87AC2AD29E35689003B0D39 /* XCRemoteSwiftPackageReference "SwiftUIDelayedGesture" */,
+			);
 			productRefGroup = 9D55B4022846289000AFD9C5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -949,7 +957,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"kko_okk/Preview Content\"";
-				DEVELOPMENT_TEAM = ML59XN7A6B;
+				DEVELOPMENT_TEAM = 22A6RK2943;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "kko-okk-Info.plist";
@@ -986,7 +994,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"kko_okk/Preview Content\"";
-				DEVELOPMENT_TEAM = ML59XN7A6B;
+				DEVELOPMENT_TEAM = 22A6RK2943;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "kko-okk-Info.plist";
@@ -1131,6 +1139,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A87AC2AD29E35689003B0D39 /* XCRemoteSwiftPackageReference "SwiftUIDelayedGesture" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ciaranrobrien/SwiftUIDelayedGesture.git";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A87AC2AE29E35689003B0D39 /* SwiftUIDelayedGesture */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A87AC2AD29E35689003B0D39 /* XCRemoteSwiftPackageReference "SwiftUIDelayedGesture" */;
+			productName = SwiftUIDelayedGesture;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		9D55B40F2846289100AFD9C5 /* kko_okk.xcdatamodeld */ = {

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -111,13 +111,13 @@ struct ButtonForContract: View {
     var commonPromiseGesture: some Gesture {
         
         let longPressGuesture = LongPressGesture(minimumDuration: 0.5)
-        // Updating: 애니메이션 적용 -> 근데 onGesture때문에 이 부분 실행 안됨
+        // Updating: 애니메이션 적용 -> onTapGesture적용시 .updating 실행 안됨
             .updating($isDetectingLongPress) { currentState, gestureState,
                 transaction in
                 gestureState = currentState
                 transaction.animation = Animation.easeIn(duration: 0.3)
             }
-        // Ended: 여기서 매칭 확인
+        // Ended: 여기서 부모 쌍과 아이 쌍의 매칭 확인
             .onEnded { _ in
                 //                    Animation.easeIn(duration: 0.3)
                 // id와 subject 확인
@@ -270,9 +270,8 @@ struct ButtonForContract: View {
                     Rectangle()
                         .fill(self.isDetectingLongPress ?
                               Color.yellow :
-                                (self.completedLongPress ? .blue : Color.yellow.opacity(0.001)))
+                                (self.completedLongPress ? Color.clear : Color.yellow.opacity(0.001)))
                         .delayedGesture(commonPromiseGesture, delay: 0.1)
-                    //여기여기
                         .onReceive(timer) { _ in
                             promisePair.resetIDPair()
                             promisePair.resetSubjectPair()

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import SwiftUIDelayedGesture
 
 struct ButtonForContract: View {
     // CoreData 사용을 위해 viewContext 받아오기
@@ -270,7 +271,7 @@ struct ButtonForContract: View {
                         .fill(self.isDetectingLongPress ?
                               Color.yellow :
                                 (self.completedLongPress ? .blue : Color.yellow.opacity(0.001)))
-                        .gesture(commonPromiseGesture)
+                        .delayedGesture(commonPromiseGesture, delay: 0.1)
                     //여기여기
                         .onReceive(timer) { _ in
                             promisePair.resetIDPair()

--- a/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
@@ -91,7 +91,7 @@ struct FilteredList: View {
                 VStack {
                     ForEach(fetchRequest) { item in
                         ButtonForContract(contract: item, nowSubject: nowSubject)
-                            .padding(25)
+                            .padding(10)
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- 셀의 LongPressGesture와 ScrollView의 Scroll Gesture가 안되는 문제를 파악했습니다. 
  - try 1) 원인을 잘 몰랐을 때 StackOverFlow에 있는 `이유는 모르겠지만 longPressGesture modifier를 추가하기 전에 .onTapGesture를 추가하면 해결된다.`라는 답변을 따라 수정해서 제스처 중첩 문제를 해결했었지만, 애니메이션이 적용되지 않는 문제가 발생했습니다.
    <img width="599" alt="Screenshot 2023-04-10 at 6 02 50 AM" src="https://user-images.githubusercontent.com/77262576/230796388-660e3361-cdbf-43d7-815a-1ddebf8ffefe.png">
  - try 2) 배포 전, 미봉책으로 Rectangle 셀들의 간격(padding)을 길게 주어서 스크롤할 수 있는 영역을 넓혔습니다.
  - try 3) ScrollView의 안에 있는 Rectangle 셀에서 바깥의 ScrollView에 접근하는 방식이나 LongPressGesture가 실행되거나 실패된 후 해당 제스처가 인식된걸 해제하는 방법을 찾아서 해결하려고 했지만, 방법을 찾지 못했습니다.
  - try 4) ⭐️Rectangle 셀 위에서 Scroll이 가능해야한다.⭐️로 문제 정의를 한 뒤, 여러 시도를 해보니 LongPressGesture의 우선순위가 높아서 생긴 문제임을 발견했습니다. `simultaneousGesture`나 `highPriorityGesture`를 사용해서 Scroll과 LongPressGesture의 우선순위를 같게 하거나 Scroll 제스처의 우선순위를 높이는 방법으로 시도했으나 실패했습니다.
  - try 5) 우선순위를 다르게 주는 방식을 고려하다가, longPressGesture에 딜레이를 걸어주는 방식을 생각했습니다. 그 결과 원하는 의도대로 잘 동작하게 되었습니다 :D 
    <img width="630" alt="Screenshot 2023-04-10 at 6 18 48 AM" src="https://user-images.githubusercontent.com/77262576/230796969-e55a7d8e-5ea4-465c-8286-097b61d1d1ed.png">


### Key Change
- ScrollView에 우선순위를 주기 위해 `SwiftUIDelayedGesture`라는 라이브러리를 사용해서 LongPressGesture에 딜레이를 걸어주었습니다.

### To Reviewers
ScrollView + LongPressGesutre + Animation 3박자가 갖춰진 사례가 없어서 해결하는 데에 애먹었는데, 문제를 정확하게 정의하고나니 생각보다 간단하게 해결하게 되었습니다!

Close #211 